### PR TITLE
pageFooter bug

### DIFF
--- a/src/classes/DiscordEmbedPages.js
+++ b/src/classes/DiscordEmbedPages.js
@@ -50,7 +50,7 @@ class DiscordEmbedPages {
          * Whether to have a page counter on the embed footers.
          * @type {Boolean}
          */
-        this.pageFooter = pageFooter || true;
+        this.pageFooter = pageFooter ?? true;
 
         /**
          * The current page number to embed pages is on.


### PR DESCRIPTION
So there is a bug where you can't set the pageFooter option and I fixed it!

The only thing I changed:
```js
-        this.pageFooter = pageFooter || true;
+        this.pageFooter = pageFooter ?? true;
```
So basically the "||" operator is a "OR" operator but the problem is that the OR operator checked if the left-hand operand is falsy (false, 0, undefined, you name it...) and if it is, it's the right-hand operand that is chosen. And this is a problem because if you specify "false" in the options, it won't work... So what I did to fix that, is use the fantastic "Nullish coalescing operator"! Basically, the only thing that differs from the OR operator is that it checks only for nullish operand (undefined or null).

(Did you even tried this option??)

I tested my code and it works perfectly fine! Otherwise, good job, I use this module a lot!

_Btw I'm French so my English is really not perfect_