### PR TITLE
Updated to Discord.js v13, changed reactions to buttons and updated your examplebot in test/ to v13 too!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## discord-pages
 **discord-pages** is an easy to use package for making discord embed pages, with many functions!
-Build with discord.js@^12.0.0.
+Build with discord.js@^13.1.0.
 ## Installation
 ```
 npm install discord-pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-pages",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -544,8 +544,8 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "discord.js": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.0.tgz",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.1.0.tgz",
       "integrity": "sha512-MXZcnBIosHEOX26ipWEcZdUrTyfTbb4sDYYp0Go5N05PyI78LR8Ds7yAfMu0zUDmxFHYLSYX0pCdiO2pd4CP6w==",
       "requires": {
         "@discordjs/collection": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-pages",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Make discord page embeds easily!",
   "main": "./src/index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/iColtz/discord-pages#readme",
   "dependencies": {
-    "discord.js": "^12.5.0"
+    "discord.js": "^13.1.0"
   },
   "devDependencies": {
     "eslint": "^7.14.0",

--- a/src/classes/DiscordEmbedPages.js
+++ b/src/classes/DiscordEmbedPages.js
@@ -1,4 +1,5 @@
-const { MessageEmbed } = require("discord.js");
+const { MessageEmbed, MessageActionRow, MessageButton } = require("discord.js");
+const packages = require('../../../../package.json')
 
 /**
  * Options used to determine how to embed pages should be constructed.
@@ -57,40 +58,83 @@ class DiscordEmbedPages {
          * @type {Number}
          */
         this.currentPageNumber = 0;
+
+        /**
+         * Throws an error when the user is not using the latest version of discord.js.
+         */
+        if (packages.dependencies["discord.js"] != "^13.1.0") throw new Error("Please install the newest version of discord.js.")
     }
 
     /**
      * Creates and sends the embed pages.
      */
     createPages() {
+
+        /**
+         * Creates a Action Row with needed buttons.
+         */
+        const row = new MessageActionRow()
+            .addComponents(
+                new MessageButton()
+                    .setCustomId('◀️')
+                    .setEmoji('◀️')
+                    .setStyle('SECONDARY'),
+                new MessageButton()
+                    .setCustomId('▶️')
+                    .setEmoji('▶️')
+                    .setStyle('SECONDARY'),
+                new MessageButton()
+                    .setCustomId('⏹')
+                    .setEmoji('⏹')
+                    .setStyle('SECONDARY')
+            );
+
         if (!this.pages[0]) throw new Error("Tried to create embed pages with no pages in the pages array.");
         if (this.pageFooter) this.pages[0].setFooter(`Page: 1/${this.pages.length}`);
-        this.channel.send({ embed: this.pages[0] }).then(msg => {
+        this.channel.send({ embeds: [this.pages[0]], components: [row] }).then(msg => {
             this.msg = msg;
-            msg.react("◀️").catch(() => null);
-            msg.react("▶️").catch(() => null);
-            msg.react("⏹").catch(() => null);
-            const filter = (reaction, user) => {
-                if (user.bot) return false;
+            const filter = (i) => {
+                if (i.user.bot) return false;
                 if (!this.restricted) return true;
-                else if (this.restricted instanceof Function) return this.restricted(user);
-                else if (Array.isArray(this.restricted) && this.restricted.includes(user.id)) return true;
-                else if (typeof this.restricted === "string" && this.restricted === user.id) return true;
+                else if (this.restricted instanceof Function) return this.restricted(i.user);
+                else if (Array.isArray(this.restricted) && this.restricted.includes(i.user.id)) return true;
+                else if (typeof this.restricted === "string" && this.restricted === i.user.id) return true;
             };
-            const collector = msg.createReactionCollector(filter, { time: this.duration });
-            collector.on("collect", (reaction, user) => {
-            reaction.users.remove(user.id);
-                switch(reaction.emoji.name) {
-                case "▶️":
-                    return this.nextPage();
-                case "◀️":
-                    return this.previousPage();
-                case "⏹":
-                    return this.delete();
+            const collector = msg.createMessageComponentCollector({ filter, componentType: 'BUTTON', time: this.duration });
+            collector.on("collect", (i) => {
+                i.deferUpdate();
+                switch (i.customId) {
+                    case "▶️":
+                        return this.nextPage();
+                    case "◀️":
+                        return this.previousPage();
+                    case "⏹":
+                        return this.delete();
                 }
             });
             collector.on("end", () => {
-                this.msg.reactions.removeAll().catch(() => null);
+                /**
+                 * Create a Action Row with disabled buttons.
+                 */
+                const disabledRow = new MessageActionRow()
+                    .addComponents(
+                        new MessageButton()
+                            .setCustomId('◀️')
+                            .setEmoji('◀️')
+                            .setDisabled(true)
+                            .setStyle('SECONDARY'),
+                        new MessageButton()
+                            .setCustomId('▶️')
+                            .setEmoji('▶️')
+                            .setDisabled(true)
+                            .setStyle('SECONDARY'),
+                        new MessageButton()
+                            .setCustomId('⏹')
+                            .setEmoji('⏹')
+                            .setDisabled(true)
+                            .setStyle('SECONDARY')
+                    );
+                this.msg.edit({ components: [disabledRow] }).catch(() => null);
             });
         });
     }
@@ -104,7 +148,7 @@ class DiscordEmbedPages {
         if (this.currentPageNumber >= this.pages.length) this.currentPageNumber = 0;
         const embed = this.pages[this.currentPageNumber];
         if (this.pageFooter) embed.setFooter(`Page: ${this.currentPageNumber + 1}/${this.pages.length}`);
-        this.msg.edit({ embed: embed }).catch(() => null);
+        this.msg.edit({ embeds: [embed] }).catch(() => null);
     }
 
     /**
@@ -116,7 +160,7 @@ class DiscordEmbedPages {
         if (this.currentPageNumber < 0) this.currentPageNumber = this.pages.length - 1;
         const embed = this.pages[this.currentPageNumber];
         if (this.pageFooter) embed.setFooter(`Page: ${this.currentPageNumber + 1}/${this.pages.length}`);
-        this.msg.edit({ embed: embed }).catch(() => null);
+        this.msg.edit({ embeds: [embed] }).catch(() => null);
     }
 
     /**
@@ -129,7 +173,7 @@ class DiscordEmbedPages {
         this.pages.push(embed);
         const currentEmbed = this.pages[this.currentPageNumber];
         if (this.pageFooter) currentEmbed.setFooter(`Page: ${this.currentPageNumber + 1}/${this.pages.length}`);
-        this.msg.edit({ embed: currentEmbed });
+        this.msg.edit({ embeds: [currentEmbed] });
     }
 
     /**
@@ -145,12 +189,12 @@ class DiscordEmbedPages {
             const embed = this.pages[this.currentPageNumber];
             if (!embed) return this.delete();
             if (this.pageFooter) embed.setFooter(`Page: ${this.currentPageNumber + 1}/${this.pages.length}`);
-            this.msg.edit({ embed: embed });
+            this.msg.edit({ embeds: [embed] });
         }
         else {
             const embed = this.pages[this.currentPageNumber];
             if (this.pageFooter) embed.setFooter(`Page: ${this.currentPageNumber + 1}/${this.pages.length}`);
-            this.msg.edit({ embed: embed });
+            this.msg.edit({ embeds: [embed] });
         }
     }
 
@@ -164,7 +208,7 @@ class DiscordEmbedPages {
         this.currentPageNumber = pageNumber;
         const embed = this.pages[this.currentPageNumber];
         if (this.pageFooter) embed.setFooter(`Page: ${this.currentPageNumber + 1}/${this.pages.length}`);
-        this.msg.edit({ embed: embed }).catch(() => null);
+        this.msg.edit({ embeds: [embed] }).catch(() => null);
     }
 
     /**

--- a/src/classes/DiscordEmbedPages.js
+++ b/src/classes/DiscordEmbedPages.js
@@ -86,7 +86,7 @@ class DiscordEmbedPages {
                 new MessageButton()
                     .setCustomId('⏹')
                     .setEmoji('⏹')
-                    .setStyle('SECONDARY')
+                    .setStyle('DANGER')
             );
 
         if (!this.pages[0]) throw new Error("Tried to create embed pages with no pages in the pages array.");

--- a/test/bot.js
+++ b/test/bot.js
@@ -1,11 +1,11 @@
 const { token } = require("./config.js");
-const { Client, MessageEmbed } = require("discord.js");
+const { Client, MessageEmbed, Intents } = require("discord.js");
 const EmbedPages = require("../src/index.js");
-const client = new Client();
+const client = new Client({ intents: [ Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_MESSAGE_REACTIONS ] });
 
 client.once("ready", () => console.log("Yoo this is ready!"));
 
-client.on("message", async (message) => {
+client.on("messageCreate", async (message) => {
     if (message.content.startsWith("?test")) {
         const embed1 = new MessageEmbed().setColor("RED").setDescription("Test Number 1");
         const embed2 = new MessageEmbed().setColor("BLUE").setDescription("Test Number 2");

--- a/test/bot.js
+++ b/test/bot.js
@@ -1,7 +1,7 @@
 const { token } = require("./config.js");
 const { Client, MessageEmbed, Intents } = require("discord.js");
 const EmbedPages = require("../src/index.js");
-const client = new Client({ intents: [ Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_MESSAGE_REACTIONS ] });
+const client = new Client({ intents: [ Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS ] });
 
 client.once("ready", () => console.log("Yoo this is ready!"));
 


### PR DESCRIPTION
Why Discord.js Version 13?
`->` **Applying the filter in your collector method has been changed along with sending embeds in messages in v13 so this would mean that people who have already updated their bot to v13 would not be able to use this package anymore unless they update it locally which is not very obvious.**

Why buttons and not reactions?
`->` **Buttons are more modern than reactions and offer more options.**

Does anything need to be adjusted before it can be merged?
`->` **Nope, I made it ready-to-merge by adjusting the version of discord.js in the package.json but also the version of the package itself, so you don't have to adjust this anymore!**
`↳` **v`1.0.3` -> v`1.0.4`**

**Embed w/ buttons:**
![img](https://i.imgur.com/cOCzL2R.png)

**Note:** When using the examplebot included in the package you will need to change line 2 of `src/classes/DiscordEmbedPages.js` to: 
```js
const packages = require('../../package.json')
```
otherwise he won't find the path of course.
